### PR TITLE
feat: implement rate limiting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -172,7 +172,7 @@ fn main() -> Result<ExitCode> {
 
             let response = Fuzzer::send_request(
                 &args.url.into(),
-                result.path.to_owned(),
+                result.path,
                 result.method,
                 &result.payload,
                 &args.header.into_iter().map(Into::into).collect(),


### PR DESCRIPTION
When 429 (Too Many Requests) or 503 (Service unavailable) status codes are received, the fuzzer will try to resend the request after number of seconds specified in `Retry-After` header. If the header is not present it will use exponential backoff algorithm with a start value of  1 second.

Closes: #23 